### PR TITLE
Fix insta api issues

### DIFF
--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -105,7 +105,8 @@ async function getProfilePicUrl(user) {
       "Public api request failed. Now attempting to parse page:",
       err
     );
-    const response = await fetch(`https://www.instagram.com/${username}`, {
+    const url = `https://www.instagram.com/${username}`
+    const response = await fetch(url, {
         headers: {
             'User-Agent': userAgent,
             'Accept-Encoding': 'gzip, deflate',

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -86,7 +86,7 @@ async function getProfilePicUrl(user) {
   // Try with Public api first, fallback to page parsing after.
   let profile_pic_url_hd = null;
   try {
-    let response = await fetch(`https://instagram.com/${user}/?__a=1`, {
+    let response = await fetch(`https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`, {
       headers: {
         cookie: sessionCookie,
       },

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -152,15 +152,15 @@ async function login(username, password) {
   };
   let response = await fetch(url, options);
   let setCookie = response.headers.raw()["set-cookie"];
-  let cookies = "";
+  let cookie = "";
 
   for (let i = 0; i < setCookie.length; i++) {
     let match = setCookie[i].match(/^[^;]+;/);
     if (match) {
-      cookies = `${cookies} ${match[0]}`;
+      cookie = `${cookie} ${match[0]}`;
     }
   }
-  return cookies;
+  return cookie;
 }
 
 // Need to get CSRF token before login.

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -218,25 +218,5 @@ let instapic = functions.runWith(secrets).https.onRequest(async (req, res) => {
   }
 })
 
-// Return image itself on requested url
-let instapicData = functions.runWith(secrets).https.onRequest(async (req, res) => {
-  let user = req.query.username
-  let url = null
-  if (user) {
-    url = await storeProfilePic(user)
-  }
 
-  if (url) {
-    const file = bucket.file(`${bucketPath}/${user}.png`).createReadStream({
-      validation: false
-    })
-    file.pipe(res)
-  } else {
-    res.status(404);
-    res.end("not found")
-  }
-
-})
-
-
-export { instapic, instapicData }
+export { instapic }

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -105,12 +105,14 @@ async function getProfilePicUrl(user) {
       "Public api request failed. Now attempting to parse page:",
       err
     );
-    let response = await fetch(`https://instagram.com/${user}`, {
-      headers: {
-        "Accept": '*/*',
-        cookie: sessionCookie,
-      },
-    });
+    const response = await fetch(`https://www.instagram.com/${username}`, {
+        headers: {
+            'User-Agent': userAgent,
+            'Accept-Encoding': 'gzip, deflate',
+            'Accept': '*/*',
+            'Connection': 'keep-alive',
+        }
+    })
     let page = await response.text();
     let match = page.match(/profile_pic_url_hd":"(.+?)"/);
 

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -89,6 +89,7 @@ async function getProfilePicUrl(user) {
     let response = await fetch(`https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`, {
       headers: {
         "user-agent": userAgent,
+        "Accept": '*/*',
         cookie: sessionCookie,
         "x-ig-app-id": 936619743392459,
       },
@@ -103,6 +104,7 @@ async function getProfilePicUrl(user) {
     );
     let response = await fetch(`https://instagram.com/${user}`, {
       headers: {
+        "Accept": '*/*',
         cookie: sessionCookie,
       },
     });
@@ -140,6 +142,7 @@ async function login(username, password) {
     headers: {
       "user-agent": userAgent,
       "x-csrftoken": csrf,
+      "Accept": '*/*',
       "x-requested-with": "XMLHttpRequest",
       referer: loginUrl,
     },

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -87,13 +87,15 @@ async function getProfilePicUrl(user) {
   let profile_pic_url_hd = null;
   try {
     let response = await fetch(`https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`, {
-      headers: {
-        "user-agent": userAgent,
-        "Accept": '*/*',
-        cookie: sessionCookie,
-        "x-ig-app-id": 936619743392459,
-      },
-    });
+        headers:{
+            'User-Agent': userAgent,
+            "x-ig-app-id": "936619743392459",
+            "x-asbd-id": "198387",
+            'Accept-Encoding': 'gzip, deflate',
+            'Accept': '*/*',
+            'Connection': 'keep-alive',
+        }
+    })
     let page = await response.json();
     profile_pic_url_hd = page.data?.user?.profile_pic_url_hd;
     await usersPath.doc(user).set({ profile_pic_url_hd });

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -93,7 +93,6 @@ async function getProfilePicUrl(user) {
         "x-ig-app-id": 936619743392459,
       },
     });
-    // TODO: Next line causes error. Resolve issue.
     let page = await response.json();
     profile_pic_url_hd = page.data?.user?.profile_pic_url_hd;
     await usersPath.doc(user).set({ profile_pic_url_hd });
@@ -108,7 +107,6 @@ async function getProfilePicUrl(user) {
       },
     });
     let page = await response.text();
-    // TODO: No match is found and profile_pic_url_hd remains null.
     let match = page.match(/profile_pic_url_hd":"(.+?)"/);
 
     profile_pic_url_hd = match !== null ? JSON.parse(`["${match[1]}"]`)[0] : null;

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -93,18 +93,8 @@ async function getProfilePicUrl(user) {
     });
     // TODO: Next line causes error. Resolve issue.
     let page = await response.json();
-    await usersPath.doc(user).set({
-      id: userInfo.id,
-      username: userInfo.username,
-      profile_pic_url_hd: userInfo.profile_pic_url_hd,
-      profile_pic_url: userInfo.profile_pic_url,
-      full_name: userInfo.full_name,
-      fbid: userInfo.fbid,
-      external_url: userInfo.external_url,
-      biography: userInfo.biography
-    });
-
-    profile_pic_url_hd = page.graphql?.user?.profile_pic_url_hd;
+    profile_pic_url_hd = page.data?.user?.profile_pic_url_hd;
+    await usersPath.doc(user).set({ profile_pic_url_hd });
   } catch (err) {
     console.log(
       "Public api request failed. Now attempting to parse page:",

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -86,7 +86,8 @@ async function getProfilePicUrl(user) {
   // Try with Public api first, fallback to page parsing after.
   let profile_pic_url_hd = null;
   try {
-    let response = await fetch(`https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`, {
+    const url = `https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`
+    const response = await fetch(url, {
         headers:{
             'User-Agent': userAgent,
             "x-ig-app-id": "936619743392459",

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -10,7 +10,7 @@ const password = process.env.INSTAGRAM_PASSWORD;
 const loginUrl = "https://www.instagram.com/accounts/login";
 // The userAgent does NOT need to be changed. Any valid userAgent will do.
 const userAgent =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36";
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
 
 // Initialize Firebase products.
 const db = new Firestore();

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -88,7 +88,9 @@ async function getProfilePicUrl(user) {
   try {
     let response = await fetch(`https://i.instagram.com/api/v1/users/web_profile_info/?username=${user}`, {
       headers: {
+        "user-agent": userAgent,
         cookie: sessionCookie,
+        "x-ig-app-id": 936619743392459,
       },
     });
     // TODO: Next line causes error. Resolve issue.

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -75,12 +75,17 @@ async function getProfilePicUrl(user) {
   if (data?.profile_pic_url_hd) {
     return data.profile_pic_url_hd;
   }
+
+  /*
+  // With this approach, a login to Instagram is no longer required.
   // Check if session exists or not.
   let sessionCookie = await getSessionCache();
   if (!sessionCookie) {
     sessionCookie = await login(username, password);
     await setSessionCache(sessionCookie);
   }
+  */
+
   // profile_pic_url_hd can be parsed from user html page itself or from Public api.
   // Public api needs more testing.
   // Try with Public api first, fallback to page parsing after.

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -201,7 +201,6 @@ const secrets = {
   ],
 };
 
-// Redirect version example.
 // Obtain image if needed and redirect to bucket public url
 let instapic = functions.runWith(secrets).https.onRequest(async (req, res) => {
   let user = req.query.username

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -105,7 +105,7 @@ async function getProfilePicUrl(user) {
       "Public api request failed. Now attempting to parse page:",
       err
     );
-    const url = `https://www.instagram.com/${username}`
+    const url = `https://www.instagram.com/${username}/?&__a=1&__d=dis`
     const response = await fetch(url, {
         headers: {
             'User-Agent': userAgent,

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,9 @@ let username = document.querySelector('#username');
 let btn = document.querySelector('#get_avatar');
 let img = document.querySelector('#result');
 
+// TODO: Set CORS proxy server based on desired environment.
+const IS_LOCAL_PROXY = true;
+
 // TODO: Set all six URLs to the values associated with your project.
 const localApiUrl = "http://localhost:5001/insta-profile-pic/us-central1/instapic";
 const remoteApiUrl = "https://us-central1-insta-profile-pic.cloudfunctions.net/instapic";
@@ -15,7 +18,7 @@ const local = window.location.hostname === "localhost"; // true if local
 // Set URLs below based on whether locally hosted emulator is running or not.
 const API_URL = local ? localApiUrl : remoteApiUrl;
 const PIC_URL = local ? localPicUrl : remotePicUrl;
-const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;
+const PROXY_URL = IS_LOCAL_PROXY ? localProxyUrl : remoteProxyUrl;
 
 btn.addEventListener('click', async e => {
   let user = username.value;

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,6 @@
 let username = document.querySelector('#username');
-let btn = document.querySelector('#get_avatar');
-let img = document.querySelector('#result');
+let button = document.querySelector('#get_avatar');
+let image = document.querySelector('#result');
 
 // TODO: Set CORS proxy server based on desired environment.
 const IS_LOCAL_PROXY = true;
@@ -20,9 +20,9 @@ const API_URL = local ? localApiUrl : remoteApiUrl;
 const PIC_URL = local ? localPicUrl : remotePicUrl;
 const PROXY_URL = IS_LOCAL_PROXY ? localProxyUrl : remoteProxyUrl;
 
-btn.addEventListener('click', async e => {
+button.addEventListener('click', async e => {
   let user = username.value;
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
   username.value = null;
-  img.src = PIC_URL + user + ".png";
+  image.src = PIC_URL + user + ".png";
 })

--- a/public/app.js
+++ b/public/app.js
@@ -21,5 +21,6 @@ btn.addEventListener('click', async e => {
   let user = username.value
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
   username.value = null
+  img.src = PIC_URL + user + ".png";
   cache_info.innerText = j.from_cache
 })

--- a/public/app.js
+++ b/public/app.js
@@ -1,6 +1,6 @@
-let username = document.querySelector('#username')
-let btn = document.querySelector('#get_avatar')
-let img = document.querySelector('#result')
+let username = document.querySelector('#username');
+let btn = document.querySelector('#get_avatar');
+let img = document.querySelector('#result');
 
 // Set API_URL based on whether locally hosted emulator is running or not.
 // TODO: Set both api urls to the values associated with your project.
@@ -10,6 +10,7 @@ const localPicUrl = "http://localhost:9199/insta-profile-pic.appspot.com/avatars
 const remotePicUrl = "gs://insta-profile-pic.appspot.com/avatars/";
 const localProxyUrl = "http://localhost:5002/private-cors-server/us-central1/proxy/";
 const remoteProxyUrl = "https://private-cors-server.herokuapp.com/";
+
 const local = window.location.hostname === "localhost"; // true if local
 
 const API_URL = local ? localApiUrl : remoteApiUrl;
@@ -17,8 +18,8 @@ const PIC_URL = local ? localPicUrl : remotePicUrl;
 const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;
 
 btn.addEventListener('click', async e => {
-  let user = username.value
+  let user = username.value;
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
-  username.value = null
+  username.value = null;
   img.src = PIC_URL + user + ".png";
 })

--- a/public/app.js
+++ b/public/app.js
@@ -1,7 +1,6 @@
 let username = document.querySelector('#username')
 let btn = document.querySelector('#get_avatar')
 let img = document.querySelector('#result')
-let cache_info = document.querySelector('#cache_info')
 
 // Set API_URL based on whether locally hosted emulator is running or not.
 // TODO: Set both api urls to the values associated with your project.
@@ -22,5 +21,4 @@ btn.addEventListener('click', async e => {
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
   username.value = null
   img.src = PIC_URL + user + ".png";
-  cache_info.innerText = j.from_cache
 })

--- a/public/app.js
+++ b/public/app.js
@@ -19,7 +19,7 @@ const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;
 
 btn.addEventListener('click', async e => {
   let user = username.value
-  let result = await fetch(`${API_URL}?username=${user}`)
+  let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
   let j = await result.json()
   console.log(j)
   username.value = null

--- a/public/app.js
+++ b/public/app.js
@@ -8,11 +8,14 @@ let cache_info = document.querySelector('#cache_info')
 const localApiUrl = "http://localhost:5001/insta-profile-pic/us-central1/instapic";
 const remoteApiUrl = "https://us-central1-insta-profile-pic.cloudfunctions.net/instapic";
 const localPicUrl = "http://localhost:9199/insta-profile-pic.appspot.com/avatars/";
-const remotePicUrl = "gs://insta-profile-pic.appspot.com/avatars/"
+const remotePicUrl = "gs://insta-profile-pic.appspot.com/avatars/";
+const localProxyUrl = "http://localhost:5002/private-cors-server/us-central1/proxy/";
+const remoteProxyUrl = "https://private-cors-server.herokuapp.com/";
 const local = window.location.hostname === "localhost"; // true if local
 
 const API_URL = local ? localApiUrl : remoteApiUrl;
 const PIC_URL = local ? localPicUrl : remotePicUrl;
+const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;
 
 btn.addEventListener('click', async e => {
   let user = username.value

--- a/public/app.js
+++ b/public/app.js
@@ -7,9 +7,12 @@ let cache_info = document.querySelector('#cache_info')
 // TODO: Set both api urls to the values associated with your project.
 const localApiUrl = "http://localhost:5001/insta-profile-pic/us-central1/instapic";
 const remoteApiUrl = "https://us-central1-insta-profile-pic.cloudfunctions.net/instapic";
+const localPicUrl = "http://localhost:9199/insta-profile-pic.appspot.com/avatars/";
+const remotePicUrl = "gs://insta-profile-pic.appspot.com/avatars/"
 const local = window.location.hostname === "localhost"; // true if local
 
 const API_URL = local ? localApiUrl : remoteApiUrl;
+const PIC_URL = local ? localPicUrl : remotePicUrl;
 
 btn.addEventListener('click', async e => {
   let user = username.value

--- a/public/app.js
+++ b/public/app.js
@@ -20,9 +20,6 @@ const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;
 btn.addEventListener('click', async e => {
   let user = username.value
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
-  let j = await result.json()
-  console.log(j)
   username.value = null
-  img.src = j.url
   cache_info.innerText = j.from_cache
 })

--- a/public/app.js
+++ b/public/app.js
@@ -2,8 +2,7 @@ let username = document.querySelector('#username');
 let btn = document.querySelector('#get_avatar');
 let img = document.querySelector('#result');
 
-// Set API_URL based on whether locally hosted emulator is running or not.
-// TODO: Set both api urls to the values associated with your project.
+// TODO: Set all six URLs to the values associated with your project.
 const localApiUrl = "http://localhost:5001/insta-profile-pic/us-central1/instapic";
 const remoteApiUrl = "https://us-central1-insta-profile-pic.cloudfunctions.net/instapic";
 const localPicUrl = "http://localhost:9199/insta-profile-pic.appspot.com/avatars/";
@@ -13,6 +12,7 @@ const remoteProxyUrl = "https://private-cors-server.herokuapp.com/";
 
 const local = window.location.hostname === "localhost"; // true if local
 
+// Set URLs below based on whether locally hosted emulator is running or not.
 const API_URL = local ? localApiUrl : remoteApiUrl;
 const PIC_URL = local ? localPicUrl : remotePicUrl;
 const PROXY_URL = local ? localProxyUrl : remoteProxyUrl;

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
     <div id="container">
         <input id="username" type="text">
         <input id="get_avatar" type="button" value="GET">
-        <span id="cache_info"></span>
         <img id="result">
     </div>
     <script type="text/javascript" src="app.js"></script>


### PR DESCRIPTION
Fixed the issues surrounding the Instagram API requests. These involved Instagram blocking directly due to changes in their API and also CORS issues. The latter was resolved using the `cors-server` project that adds the required CORS headers to the Instagram API request.

This project is not yet fully functional. It works when the `cors-server` _and_ `instapic` are locally hosted. However, when the `cors-server` instance is hosted remote on Heroku there is a `404 Not Found` error. This server is up though, and has been used successfully as a proxy with the `ravenous` app. Having both apps hosted remote has not yet been tested. It's unlikey to work is the aforementioned case doesn't. It's also not possible to deploy `cors-server` with an updated `originWhitelist` to Heroku right now since `cors-server` has been updated to use Firebase, albeit with breaking changes.