### PR TITLE
Move login code

### DIFF
--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -3,6 +3,10 @@ import { Storage } from '@google-cloud/storage';
 import functions from 'firebase-functions';
 import fetch from 'node-fetch';
 
+// The userAgent does NOT need to be changed. Any valid userAgent will do.
+const userAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
+
 // Initialize Firebase products.
 const db = new Firestore();
 const storage = new Storage();

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -115,7 +115,7 @@ let instapic = functions.https.onRequest(async (req, res) => {
     url = await storeProfilePic(user)
   }
   if (url) {
-    res.redirect(url)
+    res.send({ url });
   } else {
     console.log('not found')
     res.status(404);

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -7,7 +7,6 @@ import fetch from 'node-fetch';
 const db = new Firestore();
 const storage = new Storage();
 const usersPath = db.collection("users"); // Firestore path.
-const loginPath = db.collection("login"); // Firestore path.
 const bucketPath = "avatars"; // Firebase storage path.
 // TODO: Set bucketId below to value from firebase storage section of project.
 const bucket = storage.bucket("gs://insta-profile-pic.appspot.com");
@@ -105,7 +104,7 @@ async function getProfilePicUrl(user) {
 }
 
 // Obtain image if needed and redirect to bucket public url
-let instapic = functions.runWith(secrets).https.onRequest(async (req, res) => {
+let instapic = functions.https.onRequest(async (req, res) => {
   let user = req.query.username
   let url = null
   if (user) {

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -3,14 +3,6 @@ import { Storage } from '@google-cloud/storage';
 import functions from 'firebase-functions';
 import fetch from 'node-fetch';
 
-// Instagram credentials should be from an account created specifically for programmatic login.
-const username = process.env.INSTAGRAM_HANDLE;
-const password = process.env.INSTAGRAM_PASSWORD;
-const loginUrl = "https://www.instagram.com/accounts/login";
-// The userAgent does NOT need to be changed. Any valid userAgent will do.
-const userAgent =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
-
 // Initialize Firebase products.
 const db = new Firestore();
 const storage = new Storage();

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -67,16 +67,6 @@ async function getProfilePicUrl(user) {
     return data.profile_pic_url_hd;
   }
 
-  /*
-  // With this approach, a login to Instagram is no longer required.
-  // Check if session exists or not.
-  let sessionCookie = await getSessionCache();
-  if (!sessionCookie) {
-    sessionCookie = await login(username, password);
-    await setSessionCache(sessionCookie);
-  }
-  */
-
   // profile_pic_url_hd can be parsed from user html page itself or from Public api.
   // Public api needs more testing.
   // Try with Public api first, fallback to page parsing after.

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -68,7 +68,6 @@ async function getProfilePicUrl(user) {
   }
 
   // profile_pic_url_hd can be parsed from user html page itself or from Public api.
-  // Public api needs more testing.
   // Try with Public api first, fallback to page parsing after.
   let profile_pic_url_hd = null;
   try {

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -104,14 +104,6 @@ async function getProfilePicUrl(user) {
   return profile_pic_url_hd;
 }
 
-// Define secrets available in the app.
-const secrets = {
-  secrets: [
-    "INSTAGRAM_HANDLE",
-    "INSTAGRAM_PASSWORD",
-  ],
-};
-
 // Obtain image if needed and redirect to bucket public url
 let instapic = functions.runWith(secrets).https.onRequest(async (req, res) => {
   let user = req.query.username

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -54,10 +54,6 @@ async function storeProfilePic(user) {
   }
 }
 
-/*
- *   Helper functions below are for the above function.
- */
-
 // Get profile_pic_url_hd value from Instagram.
 async function getProfilePicUrl(user) {
   // Check Firestore user data first.
@@ -106,71 +102,6 @@ async function getProfilePicUrl(user) {
     if (profile_pic_url_hd) await usersPath.doc(user).set({ profile_pic_url_hd });
   }
   return profile_pic_url_hd;
-}
-
-// Return session cache from Firestore if it exists.
-async function getSessionCache() {
-  let doc = await loginPath.doc("__session").get();
-  let data = doc.data();
-  let cookie = data ? data.cookie : null;
-  return cookie;
-}
-
-// Store Instagram cookies in Firestore after login for use later.
-async function setSessionCache(cookie) {
-  await loginPath.doc("__session").set({
-    cookie: cookie,
-    created: new Date().toUTCString(Date.now()),
-  });
-}
-
-// Do login and return resulting cookie string.
-async function login(username, password) {
-  let url = `${loginUrl}/ajax/`;
-  let csrf = await csrfToken();
-  let options = {
-    method: "POST",
-    headers: {
-      "user-agent": userAgent,
-      "x-csrftoken": csrf,
-      "Accept": '*/*',
-      "x-requested-with": "XMLHttpRequest",
-      referer: loginUrl,
-    },
-    body: new URLSearchParams({
-      enc_password: `#PWD_INSTAGRAM_BROWSER:0:${Date.now()}:${password}`,
-      username,
-      queryParams: "{}",
-      optIntoOneTap: "false",
-    }),
-  };
-  let response = await fetch(url, options);
-  let setCookie = response.headers.raw()["set-cookie"];
-  let cookie = "";
-
-  for (let i = 0; i < setCookie.length; i++) {
-    let match = setCookie[i].match(/^[^;]+;/);
-    if (match) {
-      cookie = `${cookie} ${match[0]}`;
-    }
-  }
-  return cookie;
-}
-
-// Need to get CSRF token before login.
-async function csrfToken() {
-  let options = {
-    method: "GET",
-    headers: {
-      host: "www.instagram.com",
-      "user-agent": userAgent,
-    },
-  };
-  let response = await fetch(loginUrl, options);
-  let page = await response.text();
-  /* eslint-disable no-useless-escape */
-  let csrf = page.match(/csrf_token\":\"(.*?)\"/);
-  return csrf !== null ? csrf[1] : null;
 }
 
 // Define secrets available in the app.

--- a/functions/index.mjs
+++ b/functions/index.mjs
@@ -3,7 +3,6 @@ import { Storage } from '@google-cloud/storage';
 import functions from 'firebase-functions';
 import fetch from 'node-fetch';
 
-// TODO: Set username and password via Firebase secrets or else hardcode values below.
 // Instagram credentials should be from an account created specifically for programmatic login.
 const username = process.env.INSTAGRAM_HANDLE;
 const password = process.env.INSTAGRAM_PASSWORD;

--- a/functions/login.mjs
+++ b/functions/login.mjs
@@ -9,6 +9,14 @@ const loginUrl = "https://www.instagram.com/accounts/login";
 const userAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
 
+// Define secrets available in the app.
+const secrets = {
+  secrets: [
+    "INSTAGRAM_HANDLE",
+    "INSTAGRAM_PASSWORD",
+  ],
+};
+
 // Check if session exists or not, returns session cookie.
 // Cookie is then added to Instagram API request header.
 async function getSessionCookie() {

--- a/functions/login.mjs
+++ b/functions/login.mjs
@@ -8,3 +8,13 @@ const loginUrl = "https://www.instagram.com/accounts/login";
 // The userAgent does NOT need to be changed. Any valid userAgent will do.
 const userAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
+
+// Check if session exists or not.
+async function getSessionCookie() {
+  let sessionCookie = await getSessionCache();
+  if (!sessionCookie) {
+    sessionCookie = await login(username, password);
+    await setSessionCache(sessionCookie);
+  }
+  return sessionCookie;
+}

--- a/functions/login.mjs
+++ b/functions/login.mjs
@@ -9,6 +9,10 @@ const loginUrl = "https://www.instagram.com/accounts/login";
 const userAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
 
+// Initialize Firestore and define path.
+const db = new Firestore();
+const loginPath = db.collection("login"); // Firestore path.
+
 // Define secrets available in the app.
 const secrets = {
   secrets: [

--- a/functions/login.mjs
+++ b/functions/login.mjs
@@ -1,0 +1,10 @@
+import Firestore from '@google-cloud/firestore';
+import fetch from 'node-fetch';
+
+// Instagram credentials should be from an account created specifically for programmatic login.
+const username = process.env.INSTAGRAM_HANDLE;
+const password = process.env.INSTAGRAM_PASSWORD;
+const loginUrl = "https://www.instagram.com/accounts/login";
+// The userAgent does NOT need to be changed. Any valid userAgent will do.
+const userAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";

--- a/functions/login.mjs
+++ b/functions/login.mjs
@@ -9,7 +9,8 @@ const loginUrl = "https://www.instagram.com/accounts/login";
 const userAgent =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36";
 
-// Check if session exists or not.
+// Check if session exists or not, returns session cookie.
+// Cookie is then added to Instagram API request header.
 async function getSessionCookie() {
   let sessionCookie = await getSessionCache();
   if (!sessionCookie) {

--- a/public/app.js
+++ b/public/app.js
@@ -5,11 +5,9 @@ let image = document.querySelector('#result');
 // TODO: Set CORS proxy server based on desired environment.
 const IS_LOCAL_PROXY = true;
 
-// TODO: Set all six URLs to the values associated with your project.
+// TODO: Set all four URLs to the values associated with your project.
 const localApiUrl = "http://localhost:5001/insta-profile-pic/us-central1/instapic";
 const remoteApiUrl = "https://us-central1-insta-profile-pic.cloudfunctions.net/instapic";
-const localPicUrl = "http://localhost:9199/insta-profile-pic.appspot.com/avatars/";
-const remotePicUrl = "gs://insta-profile-pic.appspot.com/avatars/";
 const localProxyUrl = "http://localhost:5002/private-cors-server/us-central1/proxy/";
 const remoteProxyUrl = "https://private-cors-server.herokuapp.com/";
 
@@ -17,7 +15,6 @@ const local = window.location.hostname === "localhost"; // true if local
 
 // Set URLs below based on whether locally hosted emulator is running or not.
 const API_URL = local ? localApiUrl : remoteApiUrl;
-const PIC_URL = local ? localPicUrl : remotePicUrl;
 const PROXY_URL = IS_LOCAL_PROXY ? localProxyUrl : remoteProxyUrl;
 
 button.addEventListener('click', async e => {

--- a/public/app.js
+++ b/public/app.js
@@ -23,6 +23,8 @@ const PROXY_URL = IS_LOCAL_PROXY ? localProxyUrl : remoteProxyUrl;
 button.addEventListener('click', async e => {
   let user = username.value;
   let result = await fetch(`${PROXY_URL}${API_URL}?username=${user}`);
+  const json = await result.json();
+  const url = json.url;
   username.value = null;
-  image.src = PIC_URL + user + ".png";
+  image.src = url;
 })


### PR DESCRIPTION
Move the code associated with `login` and `sessionCookie` retrieval along with their helpers to a separate `login.mjs` file for now. It's not currently being utilised but may be at some point in the future.

Refactor so that we `send` rather than `redirect` the `url` to the client. This way the response can be parsed for the `url` and used directly rather than selecting hardcoded values as before.